### PR TITLE
IOS: File Protection Options

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -29,6 +29,11 @@ var normalizeFilePath = (path: string) => (path.startsWith('file://') ? path.sli
 
 type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only
+  NSFileProtectionKey?: string; // IOS only
+};
+
+type FileOptions = {
+    NSFileProtectionKey?: string; // IOS only
 };
 
 type ReadDirItem = {
@@ -185,12 +190,12 @@ var RNFS = {
     return RNFSManager.mkdir(normalizeFilePath(filepath), options).then(() => void 0);
   },
 
-  moveFile(filepath: string, destPath: string): Promise<void> {
-    return RNFSManager.moveFile(normalizeFilePath(filepath), normalizeFilePath(destPath)).then(() => void 0);
+  moveFile(filepath: string, destPath: string, options: FileOptions = {}): Promise<void> {
+    return RNFSManager.moveFile(normalizeFilePath(filepath), normalizeFilePath(destPath), options).then(() => void 0);
   },
 
-  copyFile(filepath: string, destPath: string): Promise<void> {
-    return RNFSManager.copyFile(normalizeFilePath(filepath), normalizeFilePath(destPath)).then(() => void 0);
+  copyFile(filepath: string, destPath: string, options: FileOptions = {}): Promise<void> {
+    return RNFSManager.copyFile(normalizeFilePath(filepath), normalizeFilePath(destPath), options).then(() => void 0);
   },
 
   pathForBundle(bundleNamed: string): Promise<string> {
@@ -357,7 +362,7 @@ var RNFS = {
     return RNFSManager.copyAssetsVideoIOS(imageUri, destPath);
   },
 
-  writeFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
+  writeFile(filepath: string, contents: string, encodingOrOptions?: any, fileOptions: FileOptions = {}): Promise<void> {
     var b64;
 
     var options = {
@@ -382,7 +387,7 @@ var RNFS = {
       throw new Error('Invalid encoding type "' + options.encoding + '"');
     }
 
-    return RNFSManager.writeFile(normalizeFilePath(filepath), b64).then(() => void 0);
+    return RNFSManager.writeFile(normalizeFilePath(filepath), b64, fileOptions).then(() => void 0);
   },
 
   appendFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
@@ -567,8 +572,8 @@ var RNFS = {
   ExternalStorageDirectoryPath: RNFSManager.RNFSExternalStorageDirectoryPath,
   TemporaryDirectoryPath: RNFSManager.RNFSTemporaryDirectoryPath,
   LibraryDirectoryPath: RNFSManager.RNFSLibraryDirectoryPath,
-  PicturesDirectoryPath: RNFSManager.RNFSPicturesDirectoryPath
-
+  PicturesDirectoryPath: RNFSManager.RNFSPicturesDirectoryPath,
+  FileProtectionKeys: RNFSManager.RNFSFileProtectionKeys
 };
 
 module.exports = RNFS;

--- a/FS.common.js
+++ b/FS.common.js
@@ -362,7 +362,7 @@ var RNFS = {
     return RNFSManager.copyAssetsVideoIOS(imageUri, destPath);
   },
 
-  writeFile(filepath: string, contents: string, encodingOrOptions?: any, fileOptions: FileOptions = {}): Promise<void> {
+  writeFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
     var b64;
 
     var options = {
@@ -373,7 +373,10 @@ var RNFS = {
       if (typeof encodingOrOptions === 'string') {
         options.encoding = encodingOrOptions;
       } else if (typeof encodingOrOptions === 'object') {
-        options = encodingOrOptions;
+        options = {
+            ...options,
+            ...encodingOrOptions
+        };
       }
     }
 
@@ -387,7 +390,7 @@ var RNFS = {
       throw new Error('Invalid encoding type "' + options.encoding + '"');
     }
 
-    return RNFSManager.writeFile(normalizeFilePath(filepath), b64, fileOptions).then(() => void 0);
+    return RNFSManager.writeFile(normalizeFilePath(filepath), b64, options).then(() => void 0);
   },
 
   appendFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -109,12 +109,19 @@ RCT_EXPORT_METHOD(stat:(NSString *)filepath
 
 RCT_EXPORT_METHOD(writeFile:(NSString *)filepath
                   contents:(NSString *)base64Content
+                  options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSData *data = [[NSData alloc] initWithBase64EncodedString:base64Content options:NSDataBase64DecodingIgnoreUnknownCharacters];
 
-  BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:data attributes:nil];
+  NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+
+  if ([options objectForKey:@"NSFileProtectionKey"]) {
+    [attributes setValue:[options objectForKey:@"NSFileProtectionKey"] forKey:@"NSFileProtectionKey"];
+  }
+
+  BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:data attributes:attributes];
 
   if (!success) {
     return reject(@"ENOENT", [NSString stringWithFormat:@"ENOENT: no such file or directory, open '%@'", filepath], nil);
@@ -220,8 +227,14 @@ RCT_EXPORT_METHOD(mkdir:(NSString *)filepath
 {
   NSFileManager *manager = [NSFileManager defaultManager];
 
+  NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+
+  if ([options objectForKey:@"NSFileProtectionKey"]) {
+      [attributes setValue:[options objectForKey:@"NSFileProtectionKey"] forKey:@"NSFileProtectionKey"];
+  }
+
   NSError *error = nil;
-  BOOL success = [manager createDirectoryAtPath:filepath withIntermediateDirectories:YES attributes:nil error:&error];
+    BOOL success = [manager createDirectoryAtPath:filepath withIntermediateDirectories:YES attributes:attributes error:&error];
 
   if (!success) {
     return [self reject:reject withError:error];
@@ -385,6 +398,7 @@ RCT_EXPORT_METHOD(hash:(NSString *)filepath
 
 RCT_EXPORT_METHOD(moveFile:(NSString *)filepath
                   destPath:(NSString *)destPath
+                  options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -397,11 +411,22 @@ RCT_EXPORT_METHOD(moveFile:(NSString *)filepath
     return [self reject:reject withError:error];
   }
 
+  if ([options objectForKey:@"NSFileProtectionKey"]) {
+    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+    [attributes setValue:[options objectForKey:@"NSFileProtectionKey"] forKey:@"NSFileProtectionKey"];
+    BOOL updateSuccess = [manager setAttributes:attributes ofItemAtPath:destPath error:&error];
+
+    if (!updateSuccess) {
+      return [self reject:reject withError:error];
+    }
+  }
+
   resolve(nil);
 }
 
 RCT_EXPORT_METHOD(copyFile:(NSString *)filepath
                   destPath:(NSString *)destPath
+                  options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -412,6 +437,16 @@ RCT_EXPORT_METHOD(copyFile:(NSString *)filepath
 
   if (!success) {
     return [self reject:reject withError:error];
+  }
+
+  if ([options objectForKey:@"NSFileProtectionKey"]) {
+    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+    [attributes setValue:[options objectForKey:@"NSFileProtectionKey"] forKey:@"NSFileProtectionKey"];
+    BOOL updateSuccess = [manager setAttributes:attributes ofItemAtPath:destPath error:&error];
+
+    if (!updateSuccess) {
+      return [self reject:reject withError:error];
+    }
   }
 
   resolve(nil);
@@ -868,7 +903,13 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
            @"RNFSTemporaryDirectoryPath": NSTemporaryDirectory(),
            @"RNFSLibraryDirectoryPath": [self getPathForDirectory:NSLibraryDirectory],
            @"RNFSFileTypeRegular": NSFileTypeRegular,
-           @"RNFSFileTypeDirectory": NSFileTypeDirectory
+           @"RNFSFileTypeDirectory": NSFileTypeDirectory,
+           @"RNFSFileProtectionKeys": @{
+               @"NSFileProtectionCompleteUntilFirstUserAuthentication":NSFileProtectionCompleteUntilFirstUserAuthentication,
+               @"NSFileProtectionComplete": NSFileProtectionComplete,
+               @"NSFileProtectionCompleteUnlessOpen": NSFileProtectionCompleteUnlessOpen,
+               @"NSFileProtectionNone": NSFileProtectionNone
+             }
            };
 }
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -904,13 +904,11 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
            @"RNFSLibraryDirectoryPath": [self getPathForDirectory:NSLibraryDirectory],
            @"RNFSFileTypeRegular": NSFileTypeRegular,
            @"RNFSFileTypeDirectory": NSFileTypeDirectory,
-           @"RNFSFileProtectionKeys": @{
-               @"NSFileProtectionCompleteUntilFirstUserAuthentication":NSFileProtectionCompleteUntilFirstUserAuthentication,
-               @"NSFileProtectionComplete": NSFileProtectionComplete,
-               @"NSFileProtectionCompleteUnlessOpen": NSFileProtectionCompleteUnlessOpen,
-               @"NSFileProtectionNone": NSFileProtectionNone
-             }
-           };
+           @"RNFSFileProtectionComplete": NSFileProtectionComplete,
+           @"RNFSFileProtectionCompleteUnlessOpen": NSFileProtectionCompleteUnlessOpen,
+           @"RNFSFileProtectionCompleteUntilFirstUserAuthentication": NSFileProtectionCompleteUntilFirstUserAuthentication,
+           @"RNFSFileProtectionNone": NSFileProtectionNone
+          };
 }
 
 +(void)setCompletionHandlerForIdentifier: (NSString *)identifier completionHandler: (CompletionHandler)completionHandler


### PR DESCRIPTION
Half of solution for [HouseRater/issues/3302](https://github.com/houserater/HouseRater/issues/3302)

- Added support for specifying file protections when creating a directory or moving, copying, and creating a file